### PR TITLE
Browsing a list of users

### DIFF
--- a/CodingChallenge/google/internship/browsinglist.py
+++ b/CodingChallenge/google/internship/browsinglist.py
@@ -1,0 +1,39 @@
+
+def solution(L):
+
+    def remove_extra(email):
+        email = email.replace('.',"")
+        email = email.split("+")[0]
+        return email
+
+    dic = {}
+
+    def add_email(email, pure_email):
+        if not pure_email in dic:
+            dic[pure_email] = []
+        dic[pure_email].append(email)
+
+    for email in L:
+        arr = email.split('@')
+        pure_email = remove_extra(arr[0]) + "@" + arr[1]
+        add_email(email, pure_email)
+
+    count = 0
+    for x in dic:
+        length = len(dic[x])
+        if length > 1:
+            count = count + 1
+
+    return count
+
+
+L = [
+    "a.b@example.com",
+    "x@example.com",
+    "x@exa.mple.com",
+    "ab+1@example.com",
+    "y@example.com",
+    "y@example.com",
+    "y@example.com",
+]
+print solution(L)


### PR DESCRIPTION
You were browsing a list of users registered on your site when
you noticed that some email addresses might be duplicated.

Every address consists of a local name and a domain name, separated by the
@ sign. For example, in the address "duplicate@example.com", "duplicate"
is a local name and "example.com" is a domain name.

For the purposes of this task, let's define two ways of formatting an
email address:

1. if you add dots('.') between some characters in the local name
parth of an email address, it will be forwarded to the equivalent
address without dots. For instance, email addresses of the form
"dupli.cate@example.com", "d.u.p.l.c.a.t.e@example.com" will be forwarded
to "duplicate@example.com". Please note that this doesn't work for domain
names, so "duplicate@exa.mple.com.net" is different from "duplicate@example.com.net";

2. if you add a plus("+") in the local name, everything after the plus sign
will be ignored. This allows certain emails to be filtered.

for example:

"duplicate+work@example.com" will be forwarded to "duplicate@example.com"

It is posible to use both of these formatting methods at same time.

You are give a list of addresses. We collect them together into groups,
with each group containing emails that equivalent according to the above
rules.

write fuction that given a list of emails L, will return the number of
groups whose length is greater than one.